### PR TITLE
WIP: Upgrading to Alpine 3.6 + Adding back the UID/GID capability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,26 @@
-FROM alpine:3.4
-MAINTAINER Werner Beroux <werner@beroux.com>
+FROM alpine:3.6
+LABEL Maintainer1="Werner Beroux <werner@beroux.com>"
 
 # Install required packages.
 RUN set -x \
- && apk add --no-cache --update \
-        expect \
-        git \
-        nginx \
-        openssh-client \
-        php5-fpm \
-        php5-json \
-        php5-ldap \
-        php5-openssl \
-        php5-zip \
-        s6 \
-    # Create non-root user (with a randomly chosen UID/GUI).
- && adduser john -Du 2743 -h /code/workspace \
-    # forward request and error logs to docker log collector
- && ln -sf /dev/stdout /var/log/nginx/access.log \
- && ln -sf /dev/stderr /var/log/nginx/error.log
+  && apk add --no-cache \
+    expect \
+    git \
+    nginx \
+    openssh-client \
+    php5-fpm \
+    php5-json \
+    php5-ldap \
+    php5-openssl \
+    php5-zip \
+    s6 \
+    shadow \
+    tini \
+  # Create non-root user (with a randomly chosen UID/GID).
+  && adduser john -Du 2743 -h /code/workspace \
+  # forward request and error logs to docker log collector
+  && ln -sf /dev/stdout /var/log/nginx/access.log \
+  && ln -sf /dev/stderr /var/log/nginx/error.log
 
 # Codiad and config files.
 RUN git clone https://github.com/Codiad/Codiad /default-code

--- a/root/entrypoint.sh
+++ b/root/entrypoint.sh
@@ -11,4 +11,15 @@ if [ ! -d '/code/.git' ]; then
         /code/data
 fi
 
+# Set user:group ID.
+CODIAD_UID=${CODIAD_UID:-2743}
+CODIAD_GID=${CODIAD_GID:-2743}
+
+if [ ! "$(id -u john)" -eq "$CODIAD_UID" ]; then
+    usermod -o -u "$CODIAD_UID" john
+fi
+if [ ! "$(id -g john)" -eq "$CODIAD_GID" ]; then
+    groupmod -o -g "$CODIAD_GID" john
+fi
+
 exec "$@"

--- a/root/etc/s6/php-fpm/run
+++ b/root/etc/s6/php-fpm/run
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-php-fpm
+php-fpm5


### PR DESCRIPTION
Signed-off-by: Damien DUPORTAL <damien.duportal@gmail.com>


Hello there!

I'm using your docker image for Codiad, and I had the need to move to the alpine, AND having to use GUI/UID tuning. 

So please find here a 1st version with a full upgrade to alpine Linux 3.6, released recently, and the commands usermod and groupmod are now installed (package shadow introduced in 3.6 repo).

Work to DO:

* [ ] I've also installed tini: I'm still testing. It is a process reaper that will take care of forwarding/killing anything from entrypoint.sh. Maybe we could remove s6 due to this and launch processes from shell?
* [ ] Updating documentation if you are OK?